### PR TITLE
Deduce miptable names from the sqlite3 database

### DIFF
--- a/src/copyAllTables.sh
+++ b/src/copyAllTables.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-ARRAY=(3hr 6hrLev 6hrPlev 6hrPlevpt aerannual aerdaily aerfixed aerhourly aermonthly aero Amon AmonAdj CCMI1_hourly CCMI1_monthly cf3hr cfDay cfMon cfOff cfsites CORDEX_day day em em1hr em1hrclimmon em3hr em3hrpt emDay emDaypt emDayZ emFx emMon emMonclim emMonpt emMonZ emSubhr emYr fx LImon Lmon Oclim Oday Ofx Omon Oyr SIday SImon)
-ARRAY=(3hr 6hrLev 6hrPlev 6hrPlevpt aerannual aerdaily aerfixed aerhourly aermonthly aero Amon AmonAdj cfDay cfMon cfOff  day em3hr em3hrpt emDay emDaypt emDayZ emFx emMon  emMonZ emSubhr emYr fx LImon Lmon Oclim Oday Omon Oyr SImon)
 
+SQLITE3=${SQLITE3:-sqlite3}
+CMIP6DB=${CMIP6DB:-CMIP6.sql3}
 
-
-for realm in ${ARRAY[@]}; do
+for realm in $(${SQLITE3} "${CMIP6DB}" \
+                'select distinct mipTable from CMORvar'); do
     filename="CMIP6_${realm}.json"
     echo $filename
     cp /tmp/$filename .

--- a/src/createAllTables.sh
+++ b/src/createAllTables.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
-#ARRAY=(3hr 6hrLev 6hrPlev 6hrPlevpt aerannual aerdaily aerfixed aerhourly aermonthly aero Amon AmonAdj CCMI1_hourly CCMI1_monthly cf3hr cfDay cfMon cfOff cfsites CORDEX_day day em em1hr em1hrclimmon em3hr em3hrpt emDay emDaypt emDayZ emFx emMon emMonclim emMonpt emMonZ emSubhr emYr fx LImon Lmon Oclim Oday Ofx Omon Oyr SIday SImon)
-ARRAY=(3hr 6hrLev 6hrPlev 6hrPlevpt aerannual aerdaily aerfixed aerhourly aermonthly aero Amon AmonAdj cf3hr cfDay cfMon cfSites  day em3hr em3hrpt emDay  emDayZ emFx emMon  emMonZ emSubhr emYr fx LImon Lmon Oclim Oday Omon Oyr SImon)
 
-for realm in ${ARRAY[@]}; do
+SQLITE3=${SQLITE3:-sqlite3}
+CMIP6DB=${CMIP6DB:-CMIP6.sql3}
+
+for realm in $(${SQLITE3} "${CMIP6DB}" \
+                'select distinct mipTable from CMORvar'); do
     filename="CMIP6_${realm}.json"
     #echo "Creating: ${filename}"
     echo "python CMORCreateTable.py -r ${realm} -j  > /tmp/${filename}"


### PR DESCRIPTION
This tries to use the names in the database (and indirectly from the
XML version of the DREQ) to drive the creation and copying scripts.

The database doesn't include a miptable table, so this pulls them from
the mipTable columns of the CMORvar table, which should be the same
thing.  It does mean that any miptables which don't contain any
CMORvars won't get processed, but this is probably fine.

I'm not sure if this approach is right: it might be better to keep a list of miptables in the SQL DB itself, and the list may also need to be filtered somehow.  However something _like_ this seems like a better approach than hardwiring the names of the tables, as previously.

This is related to issue #2.
