### PR TITLE
Correct stored_direction for Omon depth_coord

### DIFF
--- a/src/CMIP5_Omon_CMOR3
+++ b/src/CMIP5_Omon_CMOR3
@@ -291,7 +291,7 @@ axis_entries:{  longitude: {
 #----------------------------------	
   out_name:         "lev"	
   must_have_bounds: "yes"	
-  stored_direction: "decreasing"	
+  stored_direction: "increasing"	
   valid_min:        0.	
   valid_max:        12000.	
 #----------------------------------	


### PR DESCRIPTION
I'm not sure how the `CMIP5_*_CMOR3` files are generated, or whether there are other issues, but the `stored_direction` for `depth_coord` in [CMIP5_Omon_CMOR3](https://github.com/PCMDI/xml-cmor3-database/blob/master/src/CMIP5_Omon_CMOR3#L272) is `decreasing`, while the `stored_direction` for `depth_coord` in the ["official" CMIP5 MIP tables](https://github.com/PCMDI/cmip5-cmor-tables/blob/master/Tables/CMIP5_Omon#L272) is `increasing`. This pull request fixes this issue.
