### PR TITLE
Remove empty json mip tables

### DIFF
--- a/src/CMIP5_Omon_CMOR3
+++ b/src/CMIP5_Omon_CMOR3
@@ -291,7 +291,7 @@ axis_entries:{  longitude: {
 #----------------------------------	
   out_name:         "lev"	
   must_have_bounds: "yes"	
-  stored_direction: "decreasing"	
+  stored_direction: "increasing"	
   valid_min:        0.	
   valid_max:        12000.	
 #----------------------------------	

--- a/src/CMIP6_cfsites.json
+++ b/src/CMIP6_cfsites.json
@@ -1,1 +1,0 @@
-no Variable found for cfsites


### PR DESCRIPTION
`CMIP6_cfsites.json` is incorrectly named and contains no information. This pull request removes this file.
