### PR TITLE
Fix data_specs_version in CMIP6_grids.json MIP table

### DIFF
--- a/src/CMORCreateTable.py
+++ b/src/CMORCreateTable.py
@@ -197,10 +197,11 @@ def createFormulaVar(bJSON=True):
 # ==============================================================
 def createGrids(bJSON=True):
     """
-    Create grib tables
+    Create grid tables
     """
 
     Header = CMOR3Template.GridHeaderJSON
+    Header = replaceString(Header, data_specs_version, "data_specs_version")
     Header = replaceString(Header, cmorVersion,    "cmorVersion")
     Header = replaceString(Header, cfVersion,      "cfVersion")
     Header = replaceString(Header, activityID,      "activityID")


### PR DESCRIPTION
This pull request sets the value of the `data_specs_version` attribute in the `Header` of the [CMIP6_grids.json](https://github.com/PCMDI/xml-cmor3-database/blob/master/src/CMIP6_grids.json#L9) MIP table.